### PR TITLE
Add NestJS backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,12 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
-.env*
+.env
+.env.*
+!.env.example
 
 # vercel
 .vercel
 
 # typescript
-*.tsbuildinfo
-next-env.d.ts
+*.tsbuildinfonext-env.d.ts

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Mystic Wares is a fantasy ecommerce platform specializing in legendary weapons, 
 - **next-themes** - Dark/light mode support
 - **Lucide React** - Beautiful icons
 
-### Backend (Planned)
+### Backend
 - **NestJS** - Node.js framework
 - **Fastify** - Fast web framework
 - **Prisma** - Database ORM
@@ -46,6 +46,7 @@ medieval-ecommerce-monorepo/
 │   ├── ui/               # shadcn/ui components
 │   └── layout/           # Layout components
 ├── lib/                  # Utility functions
+├── server/               # NestJS backend
 └── styles/              # Global styles
 \`\`\`
 
@@ -77,6 +78,13 @@ medieval-ecommerce-monorepo/
 
 4. **Open your browser**
    Navigate to [http://localhost:3000](http://localhost:3000)
+
+5. **Run the backend**
+   ```bash
+   cd server
+   npm install # or pnpm install
+   npm run start:dev
+   ```
 
 ## 🛍️ Features
 
@@ -120,6 +128,17 @@ All forms use React Hook Form with Zod validation schemas for type-safe form han
 - Follow the medieval color palette (amber/yellow and brown)
 - Maintain consistent spacing and typography
 - Ensure dark mode compatibility
+
+### Backend Setup
+The `server` directory contains a basic NestJS application configured with Prisma.
+Create a `.env` file based on `.env.example` and run migrations to set up the
+database:
+
+```bash
+cd server
+pnpm install
+pnpm prisma:migrate
+```
 
 ## 📱 Responsive Breakpoints
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/mystic_wares"

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mystic-wares-backend",
+  "version": "0.1.0",
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev"
+  },
+  "dependencies": {
+    "@nestjs/common": "latest",
+    "@nestjs/core": "latest",
+    "@nestjs/platform-fastify": "latest",
+    "@prisma/client": "latest",
+    "reflect-metadata": "latest"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "latest",
+    "prisma": "latest",
+    "ts-node": "latest",
+    "typescript": "latest"
+  }
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,0 +1,15 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Product {
+  id        Int      @id @default(autoincrement())
+  name      String
+  price     Int
+  createdAt DateTime @default(now())
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from './prisma/prisma.service';
+
+@Module({
+  providers: [PrismaService],
+})
+export class AppModule {}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { PrismaService } from './prisma/prisma.service';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const prismaService = app.get(PrismaService);
+  await prismaService.enableShutdownHooks(app);
+  await app.listen(3001);
+}
+
+bootstrap();

--- a/server/src/prisma/prisma.service.ts
+++ b/server/src/prisma/prisma.service.ts
@@ -1,0 +1,15 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- provide `.env.example` handling in `.gitignore`
- document new backend in README
- bootstrap NestJS server with Prisma

## Testing
- `pnpm run lint` *(fails: next not found)*
- `npx biome check .` *(fails: npm ERR! 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d2302a6b48326803569b04fa8ffe7